### PR TITLE
Compatibility and performance updates

### DIFF
--- a/examples/webHelper.js
+++ b/examples/webHelper.js
@@ -1,7 +1,7 @@
 // WebHelperApi
 
-const AppleScriptApi = require ("../src/").SpotifyWebHelper;
-const api = new AppleScriptApi ();
+const WebHelperApi = require ("../src/").SpotifyWebHelper;
+const api = new WebHelperApi ();
 
 // Using an async function
 // You an also use Promises (.then(), .catch(), ...)

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -355,14 +350,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "is-number-like": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-      "requires": {
-        "lodash.isfinite": "3.3.2"
-      }
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -487,11 +474,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
     },
-    "lodash.isfinite": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -591,15 +573,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
-    "portscanner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-      "requires": {
-        "async": "1.5.2",
-        "is-number-like": "1.0.8"
-      }
     },
     "punycode": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-spotify-helper",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "The nicest Spotify Helper of them all. Includes SpotifyWebHelper and the public Spotify Api.",
   "main": "src/index.js",
   "scripts": {
@@ -29,7 +29,6 @@
     "fs-extra": "^4.0.1",
     "mocha": "^3.5.0",
     "node-ps": "0.0.2",
-    "portscanner": "^2.1.1",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.4"
   },


### PR DESCRIPTION
Removed the `portscanner` package, because port-scanning is extremely slow (at least on Windows, didn't test on other platforms).

As a replacement, a custom port scanner has been added.
The new port scanner should work on all platforms since it relies on the `net` module to test if binding to the port works. If it does not, and the error message is `EADDRINUSE`, the port is currently in use.
That should be a very reliable scan, and it is pretty fast.

The `getWebHelperLocation` function has been changed to throw an error in case the web helper can't be found, except simply returning false.

A small hack has been added to the `webHelperRunning` function, to prevent a 'windows not supported' error on Windows only, that happens when attempting to use `ps.lookup`. It would probably be wise to look into this some more, since comprehensive windows support is claimed by node-ps.

Furthermore, the spotilocal protocol changed from https to http in recent Spotify versions (https doesn't seem to be supported anymore). This commit changes the protocol in code to reflect those changes.